### PR TITLE
Feautre: added a method to remove/pop all children of a node

### DIFF
--- a/include/myxmlpp/Node.hpp
+++ b/include/myxmlpp/Node.hpp
@@ -444,6 +444,11 @@ namespace myxmlpp {
                                 char delimiter='/') noexcept;
 
             /**
+             * Method to remove all children of the node
+             */
+            void rmChildren() noexcept;
+
+            /**
              * Method to remove all children which have the provided tag
              * @param tag tag of the nodes to remove
              */
@@ -520,6 +525,13 @@ namespace myxmlpp {
             */
             std::shared_ptr<Node> popChildBySPath(const std::string& path,
                                                   char delimiter='/') noexcept;
+
+            /**
+             * Method to pop all children of the node
+             * @return a list of the popped nodes or an empty list
+             * if no node is found
+             */
+            std::vector<std::shared_ptr<Node>> popChildren() noexcept;
 
             /**
              * Method to pop all children which have the provided tag

--- a/src/Node/delete/pop/Node_popChildren.cpp
+++ b/src/Node/delete/pop/Node_popChildren.cpp
@@ -35,3 +35,13 @@ myxmlpp::Node::popChildren(const std::string& tag) noexcept
     } catch (NodeNotFoundException& e) {}
     return toPopNodes;
 }
+
+std::vector<std::shared_ptr<myxmlpp::Node>> myxmlpp::Node::popChildren() noexcept
+{
+    std::vector<std::shared_ptr<Node>> toPopNodes;
+
+    for (auto &c : _children)
+        toPopNodes.push_back(c);
+    _children.clear();
+    return toPopNodes;
+}

--- a/src/Node/delete/rm/Node_rmChildren.cpp
+++ b/src/Node/delete/rm/Node_rmChildren.cpp
@@ -11,3 +11,8 @@ void myxmlpp::Node::rmChildren(const std::string &tag) noexcept
 {
     auto children = popChildren(tag);
 }
+
+void myxmlpp::Node::rmChildren() noexcept
+{
+    auto children = popChildren();
+}

--- a/tests/unit-testing/Node/delete/pop/Node_popChildren.cpp
+++ b/tests/unit-testing/Node/delete/pop/Node_popChildren.cpp
@@ -50,3 +50,11 @@ TEST(Node_popChildren, many_found)
         SUCCEED();
     }
 }
+
+TEST(Node_popChildren, all)
+{
+    myxmlpp::Doc d("tests/files/unit-testing/findChildren.xml");
+
+    auto children = d.getRoot()->popChildren();
+    EXPECT_TRUE(d.getRoot()->begin() == d.getRoot()->end());
+}


### PR DESCRIPTION
Added methods Node::popChildren() and Node::rmChildren